### PR TITLE
CORS and ssl_certificate for THttpServer

### DIFF
--- a/README/CREDITS
+++ b/README/CREDITS
@@ -19,6 +19,10 @@ N: Mohammad Al-Turany
 E: m.al-turany@gsi.de
 D: QTGSI classes
 
+N: Guilherme Amadio
+E: guilherme.amadio@cern.ch
+D: TDataFrame, build system, parallel writing
+
 N: Eric Anciant
 E: eric.anciant@sodern.fr
 D: TQuaternion class
@@ -353,15 +357,11 @@ D: rootdrawtree and TSimpleAnalysis
 
 N: Enrico Guiraud
 E: enrico.guiraud@gmail.com
-D: author of the multiproc module
+D: Multiproc runtime, TDataFrame
 
 N: Thorsten Glebe
 E: T.Glebe@mpi-hd.mpg.de
 D: Original author of the Smatrix package
-
-N: Sergei Gleyzer
-E: Sergei.Gleyzer@cern.ch
-D: TMVA
 
 N: Piotr Golonka
 E: Piotr.Golonka@cern.ch
@@ -908,6 +908,10 @@ N: Evgueni Tcherniaev
 E: Evgueni.Tcherniaev@cern.ch
 D: Paint3DAlgorithms used by the LEGO and SURF options
 
+N: Enric Tejedor
+E: enric.tejedor@cern.ch
+D: IO, Parallelisation, Jupyter integration, TDataFrame
+
 N: Jan Therhaag
 E: therhaag@users.sourceforge.net
 D: author of the TMVA package
@@ -927,6 +931,10 @@ D: PROOF contributions
 N: Georg Troska
 E: georg.troska@tu-dortmund.de
 D: Enhancement of the CANDLE drawing option
+
+N: Xavier Valls
+E: xavier.valls.pla@cern.ch
+D: Interfaces to the MP and MT runtimes, parallelisation, vectorisation of fits
 
 N: Alexandre V. Vaniachine
 E: AVVaniachine@lbl.gov

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -1166,7 +1166,7 @@ void TROOT::EndOfProcessCleanups()
    fFunctions->Delete();
    fGeometries->Delete();
    fBrowsers->Delete();
-   fCanvases->Delete();
+   fCanvases->Delete("slow");
    fColors->Delete();
    fStyles->Delete();
 }

--- a/interpreter/cling/lib/Interpreter/DeclExtractor.h
+++ b/interpreter/cling/lib/Interpreter/DeclExtractor.h
@@ -102,6 +102,16 @@ namespace cling {
     ///
     bool CheckTagDeclaration(clang::TagDecl* NewTD,
                              clang::LookupResult& Previous);
+
+
+    ///\brief Validate a variable that is a CXXRecordDecl
+    ///
+    /// Currently only reports errors if the var is a lamda that captures by
+    /// copy.
+    ///
+    ///\returns whether an error was reported
+    ///
+    bool ValidateCXXRecord(clang::VarDecl* VD) const;
   };
 
 } // namespace cling

--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -1078,6 +1078,14 @@ namespace cling {
     if (addr)
       return addr;
 
+    if (const CXXRecordDecl *CXX = dyn_cast<CXXRecordDecl>(RD)) {
+      // Don't generate a stub for a destructor that does nothing
+      // This also fixes printing of lambdas and C structures as they
+      // have no dtor test/ValuePrinter/Destruction.C
+      if (CXX->hasIrrelevantDestructor())
+        return nullptr;
+    }
+
     smallstream funcname;
     funcname << "__cling_Destruct_" << RD;
 

--- a/interpreter/cling/test/ErrorRecovery/Lamda.C
+++ b/interpreter/cling/test/ErrorRecovery/Lamda.C
@@ -1,0 +1,34 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling -Xclang -verify 2>&1 | FileCheck %s
+
+// This file should be used as regression test for the value printing subsystem
+// Reproducers of fixed bugs should be put here
+
+int Var = 43;
+
+auto LD = []  { return Var; };
+auto LR = [&] { return Var; };
+
+auto LC = [=] { return Var; } // expected-warning {{capture will be by reference, not copy}}
+// CHECK: ((lambda) &) @0x{{.*}}
+
+++Var;
+LC()
+// CHECK-NEXT: (int) 44
+
+LD() == LR() && LD() == LC()
+// CHECK-NEXT: (bool) true
+
+auto LL = [=,&Var] { return Var; };
+// expected-error@input_line_24:2 {{'Var' cannot be captured because it does not have automatic storage duration}}
+// expected-note@input_line_13:2 {{'Var' declared here}}
+// expected-warning@input_line_24:2 {{capture will be by reference, not copy}}
+
+.q

--- a/interpreter/cling/test/Prompt/ValuePrinter/Destruction.C
+++ b/interpreter/cling/test/Prompt/ValuePrinter/Destruction.C
@@ -1,0 +1,86 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling -Xclang -verify 2>&1 | FileCheck %s
+// Test valueDestruction
+
+.rawInput
+
+extern "C" int printf(const char*,...);
+
+class A {
+  int m_A[2];
+public:
+  A() {}
+  ~A() { printf("A::~A()\n"); }
+};
+
+class B : public A {
+  int m_B[2];
+public:
+};
+
+extern "C" {
+  struct C {
+    int m_C[4];
+  };
+
+  typedef struct {
+    int C0, c1;
+  } C2;
+}
+
+class D {
+  int m_D[2];
+public:
+};
+
+int gTest = 0;
+
+class E {
+public:
+  ~E() { gTest = 101; }
+};
+
+.rawInput
+
+A()
+//      CHECK: (A) @0x{{[0-9a-f]+}}
+// CHECK-NEXT: A::~A()
+
+B()
+// CHECK-NEXT: (B) @0x{{[0-9a-f]+}}
+// CHECK-NEXT: A::~A()
+
+C()
+// CHECK-NEXT: (C) @0x{{[0-9a-f]+}}
+
+C2()
+// CHECK-NEXT: (C2) @0x{{[0-9a-f]+}}
+
+C2 c = {1, 2}
+// CHECK-NEXT: (C2 &) @0x{{[0-9a-f]+}}
+
+D()
+// CHECK-NEXT: (D) @0x{{[0-9a-f]+}}
+
+gTest
+// CHECK-NEXT: 0
+
+E()
+// CHECK-NEXT: (E) @0x{{[0-9a-f]+}}
+
+gTest
+// CHECK-NEXT: 101
+
+// Don't call destructor on printed lambda
+[] {}
+// CHECK-NEXT: () @0x{{[0-9a-f]+}}
+
+// expected-no-diagnostics
+.q


### PR DESCRIPTION
- enables "ssl_certificate" option for civetweb engine in THttpServer (for https)
- adds an option for CORS (Cross-Origin Resource Sharing) headers in THttpServer responses (e.g. json, xml)